### PR TITLE
add etc/rear/site.conf to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rear-*.tar.gz
 test/
 build-stamp
 /var
+etc/rear/site.conf


### PR DESCRIPTION
Prevent etc/rear/site.conf from being (accidentally) committed.